### PR TITLE
chore: update command-line syntax for v5.2

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -5,6 +5,6 @@ RUN mkdir /terasology \
     && wget -P /terasology http://jenkins.terasology.org/job/DistroOmegaRelease/lastSuccessfulBuild/artifact/distros/omega/build/distributions/TerasologyOmega.zip \
     && unzip /terasology/TerasologyOmega.zip -d /terasology \
     && rm -f /terasology/TerasologyOmega.zip
-ENTRYPOINT cd /terasology && java -jar /terasology/libs/Terasology.jar -headless -homedir=/terasology/server
+ENTRYPOINT cd /terasology && java -jar /terasology/libs/Terasology.jar --headless --homedir=/terasology/server
 VOLUME /terasology/server
 EXPOSE 25777


### PR DESCRIPTION
Terasology versions >= 5.2.0 use posix-style command line options (double-dash).

see https://github.com/MovingBlocks/Terasology/pull/4157